### PR TITLE
Add feature cards section below hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,11 +6,51 @@
   <title>Hero Page</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gradient-to-r from-indigo-500 to-purple-600 text-white flex items-center justify-center h-screen">
-  <div class="text-center px-4">
-    <h1 class="text-5xl font-bold mb-4">Welcome to My Hero Page</h1>
-    <p class="text-lg mb-6">Built with HTML and Tailwind CSS</p>
-    <a href="#" class="bg-white text-indigo-600 font-semibold px-6 py-3 rounded-full hover:bg-gray-100 transition">Get Started</a>
-  </div>
+<body class="bg-gradient-to-r from-indigo-500 to-purple-600 text-white">
+  <section class="flex items-center justify-center min-h-screen px-4">
+    <div class="text-center">
+      <h1 class="text-5xl font-bold mb-4">Welcome to My Hero Page</h1>
+      <p class="text-lg mb-6">Built with HTML and Tailwind CSS</p>
+      <a href="#" class="bg-white text-indigo-600 font-semibold px-6 py-3 rounded-full hover:bg-gray-100 transition">Get Started</a>
+    </div>
+  </section>
+
+  <section class="py-12 bg-white text-gray-800">
+    <div class="max-w-6xl mx-auto px-4">
+      <div class="grid gap-8 md:grid-cols-3">
+        <div class="text-center">
+          <div class="flex items-center justify-center w-12 h-12 mx-auto mb-4 rounded-full bg-indigo-500 text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+            </svg>
+          </div>
+          <h3 class="text-xl font-semibold mb-2">Fast Performance</h3>
+          <p class="text-gray-600">Experience lightning fast load times.</p>
+        </div>
+
+        <div class="text-center">
+          <div class="flex items-center justify-center w-12 h-12 mx-auto mb-4 rounded-full bg-indigo-500 text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <rect x="7" y="2" width="10" height="20" rx="2" ry="2" />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 18h.01" />
+            </svg>
+          </div>
+          <h3 class="text-xl font-semibold mb-2">Responsive Design</h3>
+          <p class="text-gray-600">Looks great on any device.</p>
+        </div>
+
+        <div class="text-center">
+          <div class="flex items-center justify-center w-12 h-12 mx-auto mb-4 rounded-full bg-indigo-500 text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M16 11V7a4 4 0 10-8 0v4" />
+              <rect x="6" y="11" width="12" height="10" rx="2" />
+            </svg>
+          </div>
+          <h3 class="text-xl font-semibold mb-2">Secure</h3>
+          <p class="text-gray-600">Your data is safe with us.</p>
+        </div>
+      </div>
+    </div>
+  </section>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restructure hero markup inside a section
- add new feature card section with three cards using Tailwind

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68852214a714833392af0883428dd56e